### PR TITLE
misc improvements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,17 +5,12 @@ ARG USERNAME=mochi
 # install as many dependency packages as we can from Ubuntu
 RUN apt-get update \
  && apt-get -y upgrade \
- && apt-get -y install gcc automake \
- && apt-get -y install cmake libtool pkgconf \
- && apt-get -y install git python3 bison fuse sudo vim curl \
- && apt-get -y install libfuse-dev libssl-dev \
- && apt-get -y install libfmt-dev libjson-c-dev mpich libcereal-dev \
- && apt-get -y install nlohmann-json3-dev libspdlog-dev libtclap-dev
-
-# install sshd and modify configuration to allow easy ssh from host
-RUN apt-get -y install --no-install-recommends openssh-server
-COPY configs/auth.conf /etc/ssh/sshd_config.d/auth.conf
-COPY configs/ignore-host-key.conf /etc/ssh/ssh_config.d/ignore-host-key.conf
+ && apt-get -y install \
+ gcc automake cmake libtool pkgconf \
+ git python3 bison fuse sudo vim curl \
+ libfuse-dev libssl-dev \
+ libfmt-dev libjson-c-dev mpich \
+ nlohmann-json3-dev libspdlog-dev libtclap-dev
 
 # add a user, no password, with sudo privileges
 RUN useradd -m -s /bin/bash $USERNAME \
@@ -45,6 +40,8 @@ RUN cd \
 # NOTE: we intentionally do not actually install any Mochi-specific
 # spack packages.  We save that step for the hands-on exercises
 
-# when the container starts, launch ssh service and sleep so that
-# container remains up for development
-CMD sudo service ssh restart && sleep infinity
+WORKDIR /home/$USERNAME
+
+# sleep indefinitely when the container starts so that we can connect to it
+# with interactive sessions
+CMD sleep infinity

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,9 +5,7 @@ container called "mochi-tutorial" that can be used for hands on exercises
 and general Mochi experimentation.
 
 The image is based on Ubuntu and is pre-configured to include key system
-dependencies and a baseline Spack installation.  It also runs an ssh daemon
-that that allows access to an account with the user name "mochi" with no
-password.
+dependencies and a baseline Spack installation.
 
 ## Installing Docker
 
@@ -78,15 +76,11 @@ configured to run indefinitely in detached mode and allow login for the
 docker run -d -h mt1 --name mt1 mochi-tutorial
 ```
 
-Once the container is running, you can ssh into the mochi account on it
-using the following command:
+Once the container is running, you can open a shell on it using the
+following command.
 
 ```
-# for bash shell users (most common):
-ssh mochi@$(docker exec mt1 hostname -i)
-
-# for fish shell users:
-# ssh mochi@(docker exec mt1 hostname -i)
+docker exec -it mt1 /bin/bash
 ```
 
 **At this point, your Mochi tutorial container is ready, and you may proceed
@@ -107,6 +101,7 @@ Other helpful commands include:
 - `docker ps # view which containers are currently running`
 - `docker container ls -a # list all containers, whether running or not`
 - `docker images # list available container images`
+- `docker cp <file> mt1:<file> # copy files to the container`
 
 ## updating the mochi-tutorial image on Docker Hub
 
@@ -115,10 +110,10 @@ used to generate a new image and update it on Docker Hub.
 
 - create the image following the steps described in this README.md
 - log into Docker Hub with `docker login`
-- tag the image with a name matching the repository to upload to: `docker
-  tag mochi-tutorial carns/mochi-tutorial`
-- push the image with a tag name appended: `docker push
-  carns/mochi-tutorial:latest`
+- tag the image with a name matching the repository to upload to:
+  `docker tag mochi-tutorial carns/mochi-tutorial`
+- push the image with a tag name appended:
+  `docker push carns/mochi-tutorial:latest`
 - log back out of docker hub with `docker logout`
 
 ## Running multiple containers simultaneously

--- a/docker/configs/auth.conf
+++ b/docker/configs/auth.conf
@@ -1,4 +1,0 @@
-PermitRootLogin yes
-PasswordAuthentication yes
-PermitEmptyPasswords yes
-UsePAM no

--- a/docker/configs/ignore-host-key.conf
+++ b/docker/configs/ignore-host-key.conf
@@ -1,2 +1,0 @@
-Host *
-    StrictHostKeyChecking no

--- a/docker/configs/packages.yaml
+++ b/docker/configs/packages.yaml
@@ -6,10 +6,6 @@ packages:
     externals:
     - spec: automake@1.16.5
       prefix: /usr
-  openssh:
-    externals:
-    - spec: openssh@8.9p1
-      prefix: /usr
   autoconf:
     externals:
     - spec: autoconf@2.71
@@ -81,10 +77,6 @@ packages:
   mpich:
     externals:
     - spec: mpich@4.0
-      prefix: /usr
-  cereal:
-    externals:
-    - spec: cereal@1.3.1
       prefix: /usr
   nlohmann-json:
     externals:


### PR DESCRIPTION
- eliminate Ubuntu-provided external cereal package, appears to have a problem that impacts mochi-bedrock package
- removed ssh from configuration and recommend docker exec commands to attach to containers instead (the former method was Linux-specific)
- misc cleanups